### PR TITLE
Add getSharedDynamic for the TodoManager

### DIFF
--- a/src/Butler/App/Desktop.hs
+++ b/src/Butler/App/Desktop.hs
@@ -117,10 +117,11 @@ startDesktopApp services ctx = do
                 win <- newWindow wm.windows wid (from name)
                 pure (wid, win)
 
+            renderNewWindow wid win
+
             mGuiApp <- launchApp ctx.shared.appSet name ctx.shared wid
             forM_ mGuiApp \guiApp -> do
                 atomically $ addApp wm ctx.shared guiApp
-                renderNewWindow wid win
                 forM_ mEvent $ writePipe guiApp.pipe
                 clients <- atomically (getClients ctx.shared.clients)
                 forM_ clients \client -> writePipe guiApp.pipe (AppDisplay $ UserJoined client)

--- a/src/Butler/Test.hs
+++ b/src/Butler/Test.hs
@@ -48,9 +48,8 @@ newAppClient shared appInstance = do
 withTestSharedContext :: AppSet -> (AppSharedContext -> ProcessIO ()) -> ProcessIO ()
 withTestSharedContext appSet cb = withSessions ":memory:" \sessions -> do
     processEnv <- ask
-    appSharedContext <- atomically do
-        display <- Display sessions <$> newTVar mempty
-        newAppSharedContext display processEnv appSet
+    display <- atomically (Display sessions <$> newTVar mempty)
+    appSharedContext <- newAppSharedContext display processEnv appSet
     cb appSharedContext
 
 withAppInstance :: App -> (AppSharedContext -> AppInstance -> ProcessIO ()) -> ProcessIO ()


### PR DESCRIPTION
To ensure a single instance of a shared dynamic can exist, this changes adds an MVar lock to the structure.