### PR TITLE
Add Auth.OIDC and a social login demo application

### DIFF
--- a/.weeder.toml
+++ b/.weeder.toml
@@ -1,6 +1,7 @@
 roots = [
   "Main.main",
   "ButlerDemos.multiDesktop",
+  "ButlerDemos.demoSocialAuth",
   "Butler.Service.Assistant",
   "Butler.Database",
   "Butler.App",

--- a/butler.cabal
+++ b/butler.cabal
@@ -140,6 +140,7 @@ library
     , bytestring
     , cborg-json
     , cgroup-rts-threads
+    , cryptohash-sha256
     , containers
     , directory
     , ebml
@@ -169,6 +170,7 @@ library
     , mtl
     , network
     , network-run
+    , oidc-client
     , one-line-aeson-text
     , optparse-applicative
     , posix-pty

--- a/butler.cabal
+++ b/butler.cabal
@@ -141,8 +141,8 @@ library
     , bytestring
     , cborg-json
     , cgroup-rts-threads
-    , cryptohash-sha256
     , containers
+    , cryptohash-sha256
     , directory
     , ebml
     , exceptions
@@ -266,6 +266,7 @@ executable butler
     , cborg-json
     , cgroup-rts-threads
     , containers
+    , cryptohash-sha256
     , directory
     , ebml
     , exceptions
@@ -294,6 +295,7 @@ executable butler
     , mtl
     , network
     , network-run
+    , oidc-client
     , one-line-aeson-text
     , optparse-applicative
     , posix-pty
@@ -399,6 +401,7 @@ test-suite spec
     , cborg-json
     , cgroup-rts-threads
     , containers
+    , cryptohash-sha256
     , directory
     , ebml
     , exceptions
@@ -427,6 +430,7 @@ test-suite spec
     , mtl
     , network
     , network-run
+    , oidc-client
     , one-line-aeson-text
     , optparse-applicative
     , posix-pty

--- a/butler.cabal
+++ b/butler.cabal
@@ -50,6 +50,7 @@ library
       Butler.App.RandomCat
       Butler.App.SessionManager
       Butler.App.Settings
+      Butler.App.SocialLogin
       Butler.App.SoundTest
       Butler.App.Tabletop
       Butler.App.Template

--- a/butler.cabal
+++ b/butler.cabal
@@ -60,6 +60,7 @@ library
       Butler.AppSettings
       Butler.Auth
       Butler.Auth.Guest
+      Butler.Auth.OIDC
       Butler.Auth.Invitation
       Butler.Core
       Butler.Core.Buzzer

--- a/butler.cabal
+++ b/butler.cabal
@@ -60,8 +60,8 @@ library
       Butler.AppSettings
       Butler.Auth
       Butler.Auth.Guest
-      Butler.Auth.OIDC
       Butler.Auth.Invitation
+      Butler.Auth.OIDC
       Butler.Core
       Butler.Core.Buzzer
       Butler.Core.Clock

--- a/package.yaml
+++ b/package.yaml
@@ -123,6 +123,8 @@ dependencies:
   - exceptions
   - ebml
   - jira-client
+  - oidc-client
+  - cryptohash-sha256
 
   # network
   - http-client-tls

--- a/src/Butler/App/SocialLogin.hs
+++ b/src/Butler/App/SocialLogin.hs
@@ -41,6 +41,6 @@ startSocialLoginApp ctx = do
                 Just "Click to social login" -> do
                     sendsHtml ctx.shared.clients $
                         with div_ [wid_ ctx.wid "w"] do
-                            script_ $ "window.location.href = " <> "\"https://localhost:8080/_login\""
+                            script_ $ "window.location.href = " <> "\"/_login\""
                 _ -> logError "Unknown event" ["ev" .= ev]
             _ -> pure ()

--- a/src/Butler/App/SocialLogin.hs
+++ b/src/Butler/App/SocialLogin.hs
@@ -1,0 +1,47 @@
+module Butler.App.SocialLogin (socialLoginApp) where
+
+import Butler
+import Butler.Display.Session
+
+appHtml :: Monad m => AppID -> UserName -> HtmlT m ()
+appHtml wid username =
+    with div_ [id_ (withWID wid "w"), class_ "flex m-auto"] do
+        with div_ [class_ "m-auto flex flex-col items-center justify-center"] do
+            loginButton "Click to social login"
+            div_ [] $ toHtml $ "Logged as " <> show username
+  where
+    loginButton tz =
+        div_
+            [ id_ (withWID wid "social-login-button")
+            , wsSend
+            , class_ "bg-slate-200 cursor-pointer pl-1"
+            , hxTrigger_ "click"
+            , hxVals_ ("{\"v\": \"" <> tz <> "\"}")
+            ]
+            (toHtml tz)
+
+socialLoginApp :: App
+socialLoginApp =
+    (defaultApp "SocialLogin" startSocialLoginApp)
+        { tags = fromList ["Utility"]
+        , description = "Display time"
+        , size = Just (164, 164)
+        }
+
+startSocialLoginApp :: AppContext -> ProcessIO ()
+startSocialLoginApp ctx = do
+    forever do
+        res <- atomically =<< waitTransaction 60_000 (readPipe ctx.pipe)
+        case res of
+            WaitTimeout{} -> pure ()
+            WaitCompleted (AppDisplay (UserJoined client)) -> do
+                atomically $ do
+                    username <- readTVar client.session.username
+                    sendHtml client $ appHtml ctx.wid username
+            WaitCompleted (AppTrigger ev) -> case ev.body ^? key "v" . _String of
+                Just "Click to social login" -> do
+                    sendsHtml ctx.shared.clients $
+                        with div_ [id_ "w-1"] do
+                            script_ $ "window.location.href = " <> "\"https://localhost:8080/_login\""
+                _ -> logError "Unknown event" ["ev" .= ev]
+            WaitCompleted _ -> pure ()

--- a/src/Butler/App/SocialLogin.hs
+++ b/src/Butler/App/SocialLogin.hs
@@ -5,14 +5,14 @@ import Butler.Display.Session
 
 appHtml :: Monad m => AppID -> UserName -> HtmlT m ()
 appHtml wid username =
-    with div_ [id_ (withWID wid "w"), class_ "flex m-auto"] do
+    with div_ [wid_ wid "w", class_ "flex m-auto"] do
         with div_ [class_ "m-auto flex flex-col items-center justify-center"] do
             loginButton "Click to social login"
             div_ [] $ toHtml $ "Logged as " <> show username
   where
     loginButton tz =
         div_
-            [ id_ (withWID wid "social-login-button")
+            [ wid_ wid "social-login-button"
             , wsSend
             , class_ "bg-slate-200 cursor-pointer pl-1"
             , hxTrigger_ "click"
@@ -24,24 +24,23 @@ socialLoginApp :: App
 socialLoginApp =
     (defaultApp "SocialLogin" startSocialLoginApp)
         { tags = fromList ["Utility"]
-        , description = "Display time"
+        , description = "A demo app to show a social login via OpenID Connect"
         , size = Just (164, 164)
         }
 
 startSocialLoginApp :: AppContext -> ProcessIO ()
 startSocialLoginApp ctx = do
     forever do
-        res <- atomically =<< waitTransaction 60_000 (readPipe ctx.pipe)
+        res <- atomically $ readPipe ctx.pipe
         case res of
-            WaitTimeout{} -> pure ()
-            WaitCompleted (AppDisplay (UserJoined client)) -> do
+            AppDisplay (UserJoined client) -> do
                 atomically $ do
                     username <- readTVar client.session.username
                     sendHtml client $ appHtml ctx.wid username
-            WaitCompleted (AppTrigger ev) -> case ev.body ^? key "v" . _String of
+            AppTrigger ev -> case ev.body ^? key "v" . _String of
                 Just "Click to social login" -> do
                     sendsHtml ctx.shared.clients $
-                        with div_ [id_ "w-1"] do
+                        with div_ [wid_ ctx.wid "w"] do
                             script_ $ "window.location.href = " <> "\"https://localhost:8080/_login\""
                 _ -> logError "Unknown event" ["ev" .= ev]
-            WaitCompleted _ -> pure ()
+            _ -> pure ()

--- a/src/Butler/Auth.hs
+++ b/src/Butler/Auth.hs
@@ -6,6 +6,7 @@ import Butler.Display
 import Butler.Frame
 import Butler.Prelude
 import Lucid.XStatic
+import Butler.Auth.OIDC (oIDCAuthApp)
 
 newtype PageTitle = PageTitle Text
     deriving newtype (IsString, ToHtml)
@@ -17,6 +18,11 @@ publicDisplayApp :: PageTitle -> Maybe PageDesc -> DisplayApplication
 publicDisplayApp appTitle appDescM = DisplayApplication auth
   where
     auth xfiles sessions = guestAuthApp sessions $ htmlMain xfiles appTitle appDescM
+
+publicOIDCDisplayApp :: PageTitle -> Maybe PageDesc -> DisplayApplication
+publicOIDCDisplayApp appTitle appDescM = DisplayApplication auth
+  where
+    auth xfiles sessions = oIDCAuthApp sessions $ htmlMain xfiles appTitle appDescM
 
 htmlMain :: [XStaticFile] -> PageTitle -> Maybe PageDesc -> Html () -> Html ()
 htmlMain xfiles title descM body = do

--- a/src/Butler/Auth.hs
+++ b/src/Butler/Auth.hs
@@ -2,7 +2,7 @@
 module Butler.Auth where
 
 import Butler.Auth.Guest
-import Butler.Auth.OIDC (oIDCAuthApp)
+import Butler.Auth.OIDC
 import Butler.Display
 import Butler.Frame
 import Butler.Prelude
@@ -19,10 +19,13 @@ publicDisplayApp appTitle appDescM = DisplayApplication auth
   where
     auth xfiles sessions = guestAuthApp sessions $ htmlMain xfiles appTitle appDescM
 
-publicOIDCDisplayApp :: PageTitle -> Maybe PageDesc -> DisplayApplication
-publicOIDCDisplayApp appTitle appDescM = DisplayApplication auth
+publicOIDCDisplayApp :: OIDCClientID -> OIDCClientSecret -> PageTitle -> Maybe PageDesc -> DisplayApplication
+publicOIDCDisplayApp client_id client_password appTitle appDescM = DisplayApplication auth
   where
-    auth xfiles sessions = oIDCAuthApp sessions $ htmlMain xfiles appTitle appDescM
+    auth xfiles sessions =
+        oIDCAuthApp sessions public_url client_id client_password $
+            htmlMain xfiles appTitle appDescM
+    public_url = "https://localhost:8080/"
 
 htmlMain :: [XStaticFile] -> PageTitle -> Maybe PageDesc -> Html () -> Html ()
 htmlMain xfiles title descM body = do

--- a/src/Butler/Auth.hs
+++ b/src/Butler/Auth.hs
@@ -2,11 +2,11 @@
 module Butler.Auth where
 
 import Butler.Auth.Guest
+import Butler.Auth.OIDC (oIDCAuthApp)
 import Butler.Display
 import Butler.Frame
 import Butler.Prelude
 import Lucid.XStatic
-import Butler.Auth.OIDC (oIDCAuthApp)
 
 newtype PageTitle = PageTitle Text
     deriving newtype (IsString, ToHtml)

--- a/src/Butler/Auth/OIDC.hs
+++ b/src/Butler/Auth/OIDC.hs
@@ -9,67 +9,74 @@ import Butler.Display.Session
 import Butler.Display.WebSocket
 import Butler.Prelude
 
+import Crypto.Hash.SHA256 (hash)
+import Data.Aeson (encode)
+import Data.ByteString.Base64 qualified as B64
+import Data.ByteString.Char8 qualified as B
+import Data.ByteString.Lazy qualified as BSL
+import Data.Map.Strict qualified as HM
 import Data.Time (UTCTime (..), fromGregorian)
+import Network.HTTP.Client (Manager)
+import Network.HTTP.Client.TLS (newTlsManager)
 import Servant
 import Servant.Auth as SA
 import Servant.Auth.Server as SAS
 import Servant.HTML.Lucid
-import Data.Map.Strict qualified as HM
-import Web.OIDC.Client qualified as O
-import Network.HTTP.Client (Manager)
-import Data.ByteString.Base64 qualified as B64
-import Data.ByteString.Lazy qualified as BSL
-import Data.ByteString.Char8 qualified as B
-import qualified System.Random as Random
 import System.Random (genByteString)
-import Crypto.Hash.SHA256 (hash)
-import Data.Aeson (encode)
-import Network.HTTP.Client.TLS (newTlsManager)
+import System.Random qualified as Random
+import Web.OIDC.Client qualified as O
 
 type AuthResp = Headers '[Header "Set-Cookie" SetCookie, Header "Set-Cookie" SetCookie] (Html ())
-type LoginAPI = Get '[HTML] (Html ()) :<|> "_login" :> Get '[JSON] NoContent :<|> "_cb" :> Get '[HTML] AuthResp
+type LoginAPI =
+    Get '[HTML] (Html ())
+        :<|> "_login" :> Get '[JSON] NoContent
+        :<|> "_cb"
+            :> QueryParam "error" Text
+            :> QueryParam "code" Text
+            :> QueryParam "state" Text
+            :> Get '[HTML] AuthResp
 
 type AuthAPI = Auth '[SA.JWT, SA.Cookie] SessionID :> (LoginAPI :<|> Capture "workspace" Workspace :> LoginAPI)
 
-authServer :: OS -> Process -> Sessions -> (Html () -> Html ()) -> JWTSettings -> ServerT AuthAPI Servant.Handler
-authServer os process sessions mkIndexHtml jwtSettings auth =
-    let loginSrv = loginServer os process sessions mkIndexHtml jwtSettings auth
+authServer :: OS -> Process -> Sessions -> (Html () -> Html ()) -> JWTSettings -> OIDCEnv -> ServerT AuthAPI Servant.Handler
+authServer os process sessions mkIndexHtml jwtSettings auth oidcenv =
+    let loginSrv = loginServer os process sessions mkIndexHtml jwtSettings oidcenv auth
      in loginSrv Nothing :<|> (loginSrv . Just)
 
 data OIDCProviderConfig = OIDCProviderConfig
-  { opIssuerURL :: Text
-  , opClientID :: Text
-  , opClientSecret :: Text
-  , opAppPublicURL :: Text
-  , opUserClaim :: Maybe Text
-  , opEnforceAuth :: Bool
-  , opName :: Text
-  }
+    { opIssuerURL :: Text
+    , opClientID :: Text
+    , opClientSecret :: Text
+    , opAppPublicURL :: Text
+    , opUserClaim :: Maybe Text
+    , opEnforceAuth :: Bool
+    , opName :: Text
+    }
 data OIDCEnv = OIDCEnv
-  { oidc :: O.OIDC
-  , manager :: Manager
-  , provider :: O.Provider
-  , redirectUri :: ByteString
-  , sessionStoreStorage :: MVar (HM.Map O.State O.Nonce)
-  , providerConfig :: OIDCProviderConfig
-  }
+    { oidc :: O.OIDC
+    , manager :: Manager
+    , provider :: O.Provider
+    , redirectUri :: ByteString
+    , sessionStoreStorage :: MVar (HM.Map O.State O.Nonce)
+    , providerConfig :: OIDCProviderConfig
+    }
 
 initOIDCEnv :: OIDCProviderConfig -> IO OIDCEnv
-initOIDCEnv providerConfig@OIDCProviderConfig {..} = do
-  manager <- newTlsManager
-  provider <- O.discover opIssuerURL manager
-  sessionStoreStorage <- newMVar HM.empty
-  let redirectUri = encodeUtf8 opAppPublicURL <> "_cb"
-      clientId = encodeUtf8 opClientID
-      clientSecret = encodeUtf8 opClientSecret
-      oidc = O.setCredentials clientId clientSecret redirectUri (O.newOIDC provider)
-  pure OIDCEnv {..}
+initOIDCEnv providerConfig@OIDCProviderConfig{..} = do
+    manager <- newTlsManager
+    provider <- O.discover opIssuerURL manager
+    sessionStoreStorage <- newMVar HM.empty
+    let redirectUri = encodeUtf8 opAppPublicURL <> "_cb"
+        clientId = encodeUtf8 opClientID
+        clientSecret = encodeUtf8 opClientSecret
+        oidc = O.setCredentials clientId clientSecret redirectUri (O.newOIDC provider)
+    pure OIDCEnv{..}
 
 data OIDCState = OIDCState
-  { randomT :: Text
-  , uri :: Maybe Text
-  }
-  deriving (Generic, Show)
+    { randomT :: Text
+    , uri :: Maybe Text
+    }
+    deriving (Generic, Show)
 
 instance FromJSON OIDCState
 
@@ -82,44 +89,57 @@ genRandomB64 = B64.encode . hash <$> genRandom
 -- | Generate a random fixed size string of 1024 Bytes
 genRandom :: IO ByteString
 genRandom = do
-  g <- Random.newStdGen
-  let (bs, _ng) = genByteString 1024 g
-  pure bs
+    g <- Random.newStdGen
+    let (bs, _ng) = genByteString 1024 g
+    pure bs
 
 mkSessionStore :: OIDCEnv -> Maybe O.State -> Maybe Text -> O.SessionStore IO
-mkSessionStore OIDCEnv {sessionStoreStorage} stateM uriM = do
-  let sessionStoreGenerate = do
-        rb <- liftIO genRandomB64
-        let s = OIDCState (decodeUtf8 rb) uriM
-        pure (B64.encode $ BSL.toStrict $ Data.Aeson.encode s)
-      sessionStoreSave = storeSave
-      sessionStoreGet = storeGet
-      sessionStoreDelete = case stateM of
-        Just state' -> modifyMVar_ sessionStoreStorage $ \store -> pure $ HM.delete state' store
-        Nothing -> pure ()
-   in O.SessionStore {..}
- where
-  storeSave :: O.State -> O.Nonce -> IO ()
-  storeSave state' nonce = modifyMVar_ sessionStoreStorage $ \store -> pure $ HM.insert state' nonce store
-  storeGet :: O.State -> IO (Maybe O.Nonce)
-  storeGet state' = do
-    store <- readMVar sessionStoreStorage
-    let nonce = HM.lookup state' store
-    pure nonce
-
-loginServer :: OS -> Process -> Sessions -> (Html () -> Html ()) -> JWTSettings -> AuthResult SessionID -> Maybe Workspace -> ServerT LoginAPI Servant.Handler
-loginServer os process sessions mkIndexHtml jwtSettings auth mWorkspace =
-    indexRoute auth :<|> loginRoute :<|> callbackRoute
+mkSessionStore OIDCEnv{sessionStoreStorage} stateM uriM = do
+    let sessionStoreGenerate = do
+            rb <- liftIO genRandomB64
+            let s = OIDCState (decodeUtf8 rb) uriM
+            pure (B64.encode $ BSL.toStrict $ Data.Aeson.encode s)
+        sessionStoreSave = storeSave
+        sessionStoreGet = storeGet
+        sessionStoreDelete = case stateM of
+            Just state' -> modifyMVar_ sessionStoreStorage $ \store -> pure $ HM.delete state' store
+            Nothing -> pure ()
+     in O.SessionStore{..}
   where
-    callbackRoute :: Servant.Handler AuthResp
-    callbackRoute = do
-        let provider = SessionProvider "google"
-        session <- liftIO $ runProcessIO os process $ newSession sessions provider "guest"
-        liftIO (SAS.acceptLogin cookieSettings jwtSettings session.sessionID) >>= \case
-            Just r -> do
-                let page = workspaceUrl mWorkspace
-                pure $ r (script_ $ "window.location.href = " <> showT page)
-            Nothing -> error "oops?!"
+    storeSave :: O.State -> O.Nonce -> IO ()
+    storeSave state' nonce = modifyMVar_ sessionStoreStorage $ \store -> pure $ HM.insert state' nonce store
+    storeGet :: O.State -> IO (Maybe O.Nonce)
+    storeGet state' = do
+        store <- readMVar sessionStoreStorage
+        let nonce = HM.lookup state' store
+        pure nonce
+
+loginServer :: OS -> Process -> Sessions -> (Html () -> Html ()) -> JWTSettings -> AuthResult SessionID -> OIDCEnv -> Maybe Workspace -> ServerT LoginAPI Servant.Handler
+loginServer os process sessions mkIndexHtml jwtSettings auth oidcenv mWorkspace =
+    indexRoute auth :<|> loginRoute oidcenv :<|> callbackRoute oidcenv
+  where
+    callbackRoute :: OIDCEnv -> Maybe Text -> Maybe Text -> Maybe Text -> Servant.Handler AuthResp
+    callbackRoute oidcEnv errM codeM stateM = do
+        case (errM, codeM, stateM) of
+            (Just errorMsg, _, _) -> error $ "Error from remote provider: " <> show errorMsg
+            (_, Nothing, _) -> error "No code parameter given"
+            (_, _, Nothing) -> error "No state parameter given"
+            (_, Just oauthCode, Just oauthState) -> do
+                tokens :: O.Tokens Value <-
+                    liftIO $
+                        O.getValidTokens
+                            (mkSessionStore oidcEnv (Just $ encodeUtf8 oauthState) Nothing)
+                            (oidc oidcEnv)
+                            (manager oidcEnv)
+                            (encodeUtf8 oauthState)
+                            (encodeUtf8 oauthCode)
+                let provider = SessionProvider "google"
+                session <- liftIO $ runProcessIO os process $ newSession sessions provider (UserName tokens.idToken.sub)
+                liftIO (SAS.acceptLogin cookieSettings jwtSettings session.sessionID) >>= \case
+                    Just r -> do
+                        let page = workspaceUrl mWorkspace
+                        pure $ r (script_ $ "window.location.href = " <> showT page)
+                    Nothing -> error "oops?!"
 
     indexRoute :: AuthResult SessionID -> Servant.Handler (Html ())
     indexRoute = \case
@@ -133,24 +153,20 @@ loginServer os process sessions mkIndexHtml jwtSettings auth mWorkspace =
                     pure "Unknown session"
         _ -> throwError $ err303{errHeaders = [("Location", encodeUtf8 (workspaceUrl mWorkspace) <> "_login")]}
 
-    loginRoute :: Servant.Handler NoContent
-    loginRoute = do
-        oidcenv <- liftIO . initOIDCEnv $
-                OIDCProviderConfig
-                    "https://accounts.google.com"
-                    "my_client_id"
-                    "my_client_secret"
-                    "https://localhost:8080"
-                    (Just "email")
-                    False
-                    "Test"
-        redirectLocation <- liftIO (genOIDCURL oidcenv)
+    loginRoute :: OIDCEnv -> Servant.Handler NoContent
+    loginRoute oidcEnv = do
+        redirectLocation <- liftIO genOIDCURL
         throwError $ err303{errHeaders = [("Location", redirectLocation)]}
-        where
-            genOIDCURL :: OIDCEnv -> IO ByteString
-            genOIDCURL oidcenv@OIDCEnv {oidc} = do
-                loc <- O.prepareAuthenticationRequestUrl (mkSessionStore oidcenv Nothing Nothing) oidc [O.openId] mempty
-                pure . B.pack $ show loc
+      where
+        genOIDCURL :: IO ByteString
+        genOIDCURL = do
+            loc <-
+                O.prepareAuthenticationRequestUrl
+                    (mkSessionStore oidcEnv Nothing Nothing)
+                    oidcEnv.oidc
+                    [O.openId]
+                    mempty
+            pure . B.pack $ show loc
 
 cookieSettings :: CookieSettings
 cookieSettings =
@@ -166,6 +182,16 @@ oIDCAuthApp sessions mkIndexHtml = do
     let jwtSettings = defaultJWTSettings myKey
     let cfg = cookieSettings :. jwtSettings :. EmptyContext
     env <- ask
-    let authSrv = authServer env.os env.process sessions mkIndexHtml jwtSettings
+    oidcenv <-
+        liftIO . initOIDCEnv $
+            OIDCProviderConfig
+                "https://accounts.google.com"
+                "my_client_id"
+                "my_client_secret"
+                "https://localhost:8080"
+                (Just "email")
+                False
+                "Test"
+    let authSrv = authServer env.os env.process sessions mkIndexHtml jwtSettings oidcenv
     let app = Servant.serveWithContextT (Proxy @AuthAPI) cfg id authSrv
     pure $ AuthApplication app

--- a/src/Butler/Auth/OIDC.hs
+++ b/src/Butler/Auth/OIDC.hs
@@ -14,9 +14,20 @@ import Servant
 import Servant.Auth as SA
 import Servant.Auth.Server as SAS
 import Servant.HTML.Lucid
+import Data.Map.Strict qualified as HM
+import Web.OIDC.Client qualified as O
+import Network.HTTP.Client (Manager)
+import Data.ByteString.Base64 qualified as B64
+import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Char8 qualified as B
+import qualified System.Random as Random
+import System.Random (genByteString)
+import Crypto.Hash.SHA256 (hash)
+import Data.Aeson (encode)
+import Network.HTTP.Client.TLS (newTlsManager)
 
 type AuthResp = Headers '[Header "Set-Cookie" SetCookie, Header "Set-Cookie" SetCookie] (Html ())
-type LoginAPI = Get '[HTML] (Html ()) :<|> "_login" :> Get '[HTML] AuthResp
+type LoginAPI = Get '[HTML] (Html ()) :<|> "_login" :> Get '[JSON] NoContent :<|> "_cb" :> Get '[HTML] AuthResp
 
 type AuthAPI = Auth '[SA.JWT, SA.Cookie] SessionID :> (LoginAPI :<|> Capture "workspace" Workspace :> LoginAPI)
 
@@ -25,12 +36,83 @@ authServer os process sessions mkIndexHtml jwtSettings auth =
     let loginSrv = loginServer os process sessions mkIndexHtml jwtSettings auth
      in loginSrv Nothing :<|> (loginSrv . Just)
 
+data OIDCProviderConfig = OIDCProviderConfig
+  { opIssuerURL :: Text
+  , opClientID :: Text
+  , opClientSecret :: Text
+  , opAppPublicURL :: Text
+  , opUserClaim :: Maybe Text
+  , opEnforceAuth :: Bool
+  , opName :: Text
+  }
+data OIDCEnv = OIDCEnv
+  { oidc :: O.OIDC
+  , manager :: Manager
+  , provider :: O.Provider
+  , redirectUri :: ByteString
+  , sessionStoreStorage :: MVar (HM.Map O.State O.Nonce)
+  , providerConfig :: OIDCProviderConfig
+  }
+
+initOIDCEnv :: OIDCProviderConfig -> IO OIDCEnv
+initOIDCEnv providerConfig@OIDCProviderConfig {..} = do
+  manager <- newTlsManager
+  provider <- O.discover opIssuerURL manager
+  sessionStoreStorage <- newMVar HM.empty
+  let redirectUri = encodeUtf8 opAppPublicURL <> "_cb"
+      clientId = encodeUtf8 opClientID
+      clientSecret = encodeUtf8 opClientSecret
+      oidc = O.setCredentials clientId clientSecret redirectUri (O.newOIDC provider)
+  pure OIDCEnv {..}
+
+data OIDCState = OIDCState
+  { randomT :: Text
+  , uri :: Maybe Text
+  }
+  deriving (Generic, Show)
+
+instance FromJSON OIDCState
+
+instance ToJSON OIDCState
+
+-- | Generate a random fixed size string of 42 char base64 encoded
+genRandomB64 :: IO ByteString
+genRandomB64 = B64.encode . hash <$> genRandom
+
+-- | Generate a random fixed size string of 1024 Bytes
+genRandom :: IO ByteString
+genRandom = do
+  g <- Random.newStdGen
+  let (bs, _ng) = genByteString 1024 g
+  pure bs
+
+mkSessionStore :: OIDCEnv -> Maybe O.State -> Maybe Text -> O.SessionStore IO
+mkSessionStore OIDCEnv {sessionStoreStorage} stateM uriM = do
+  let sessionStoreGenerate = do
+        rb <- liftIO genRandomB64
+        let s = OIDCState (decodeUtf8 rb) uriM
+        pure (B64.encode $ BSL.toStrict $ Data.Aeson.encode s)
+      sessionStoreSave = storeSave
+      sessionStoreGet = storeGet
+      sessionStoreDelete = case stateM of
+        Just state' -> modifyMVar_ sessionStoreStorage $ \store -> pure $ HM.delete state' store
+        Nothing -> pure ()
+   in O.SessionStore {..}
+ where
+  storeSave :: O.State -> O.Nonce -> IO ()
+  storeSave state' nonce = modifyMVar_ sessionStoreStorage $ \store -> pure $ HM.insert state' nonce store
+  storeGet :: O.State -> IO (Maybe O.Nonce)
+  storeGet state' = do
+    store <- readMVar sessionStoreStorage
+    let nonce = HM.lookup state' store
+    pure nonce
+
 loginServer :: OS -> Process -> Sessions -> (Html () -> Html ()) -> JWTSettings -> AuthResult SessionID -> Maybe Workspace -> ServerT LoginAPI Servant.Handler
-loginServer os process sessions mkIndexHtml jwtSettings auth mWorkspace = indexRoute auth :<|> getSessionRoute
+loginServer os process sessions mkIndexHtml jwtSettings auth mWorkspace =
+    indexRoute auth :<|> loginRoute :<|> callbackRoute
   where
-    -- Create session on _login request
-    getSessionRoute :: Servant.Handler AuthResp
-    getSessionRoute = do
+    callbackRoute :: Servant.Handler AuthResp
+    callbackRoute = do
         let provider = SessionProvider "google"
         session <- liftIO $ runProcessIO os process $ newSession sessions provider "guest"
         liftIO (SAS.acceptLogin cookieSettings jwtSettings session.sessionID) >>= \case
@@ -50,6 +132,25 @@ loginServer os process sessions mkIndexHtml jwtSettings auth mWorkspace = indexR
                     liftIO $ runProcessIO os process $ logError "no more auth?" ["id" .= sessionID]
                     pure "Unknown session"
         _ -> throwError $ err303{errHeaders = [("Location", encodeUtf8 (workspaceUrl mWorkspace) <> "_login")]}
+
+    loginRoute :: Servant.Handler NoContent
+    loginRoute = do
+        oidcenv <- liftIO . initOIDCEnv $
+                OIDCProviderConfig
+                    "https://accounts.google.com"
+                    "my_client_id"
+                    "my_client_secret"
+                    "https://localhost:8080"
+                    (Just "email")
+                    False
+                    "Test"
+        redirectLocation <- liftIO (genOIDCURL oidcenv)
+        throwError $ err303{errHeaders = [("Location", redirectLocation)]}
+        where
+            genOIDCURL :: OIDCEnv -> IO ByteString
+            genOIDCURL oidcenv@OIDCEnv {oidc} = do
+                loc <- O.prepareAuthenticationRequestUrl (mkSessionStore oidcenv Nothing Nothing) oidc [O.openId] mempty
+                pure . B.pack $ show loc
 
 cookieSettings :: CookieSettings
 cookieSettings =

--- a/src/Butler/Auth/OIDC.hs
+++ b/src/Butler/Auth/OIDC.hs
@@ -137,7 +137,7 @@ authServer os process sessions mkIndexHtml jwtSettings oidcenv =
         { authRoute = \auth ->
             WorkspaceAPI
                 { withoutWorkspace = loginServer auth Nothing
-                , withWorkspace = \ws -> loginServer auth (Just ws)
+                , withWorkspace = loginServer auth . Just
                 }
         }
   where

--- a/src/Butler/Auth/OIDC.hs
+++ b/src/Butler/Auth/OIDC.hs
@@ -1,0 +1,70 @@
+module Butler.Auth.OIDC (oIDCAuthApp) where
+
+import Lucid
+
+import Butler.Core
+import Butler.Display
+import Butler.Display.GUI
+import Butler.Display.Session
+import Butler.Display.WebSocket
+import Butler.Prelude
+
+import Data.Time (UTCTime (..), fromGregorian)
+import Servant
+import Servant.Auth as SA
+import Servant.Auth.Server as SAS
+import Servant.HTML.Lucid
+
+type AuthResp = Headers '[Header "Set-Cookie" SetCookie, Header "Set-Cookie" SetCookie] (Html ())
+type LoginAPI = Get '[HTML] (Html ()) :<|> "_login" :> Get '[HTML] AuthResp
+
+type AuthAPI = Auth '[SA.JWT, SA.Cookie] SessionID :> (LoginAPI :<|> Capture "workspace" Workspace :> LoginAPI)
+
+authServer :: OS -> Process -> Sessions -> (Html () -> Html ()) -> JWTSettings -> ServerT AuthAPI Servant.Handler
+authServer os process sessions mkIndexHtml jwtSettings auth =
+    let loginSrv = loginServer os process sessions mkIndexHtml jwtSettings auth
+     in loginSrv Nothing :<|> (loginSrv . Just)
+
+loginServer :: OS -> Process -> Sessions -> (Html () -> Html ()) -> JWTSettings -> AuthResult SessionID -> Maybe Workspace -> ServerT LoginAPI Servant.Handler
+loginServer os process sessions mkIndexHtml jwtSettings auth mWorkspace = indexRoute auth :<|> getSessionRoute
+  where
+    -- Create session on _login request
+    getSessionRoute :: Servant.Handler AuthResp
+    getSessionRoute = do
+        let provider = SessionProvider "google"
+        session <- liftIO $ runProcessIO os process $ newSession sessions provider "guest"
+        liftIO (SAS.acceptLogin cookieSettings jwtSettings session.sessionID) >>= \case
+            Just r -> do
+                let page = workspaceUrl mWorkspace
+                pure $ r (script_ $ "window.location.href = " <> showT page)
+            Nothing -> error "oops?!"
+
+    indexRoute :: AuthResult SessionID -> Servant.Handler (Html ())
+    indexRoute = \case
+        Authenticated sessionID -> do
+            mSession <- atomically (lookupSession sessions sessionID)
+            case mSession of
+                Just _ ->
+                    pure $ mkIndexHtml (websocketHtml (workspaceUrl mWorkspace))
+                Nothing -> do
+                    liftIO $ runProcessIO os process $ logError "no more auth?" ["id" .= sessionID]
+                    pure "Unknown session"
+        _ -> throwError $ err303{errHeaders = [("Location", encodeUtf8 (workspaceUrl mWorkspace) <> "_login")]}
+
+cookieSettings :: CookieSettings
+cookieSettings =
+    defaultCookieSettings
+        { cookieSameSite = SameSiteStrict
+        , cookieXsrfSetting = Nothing
+        , cookieExpires = Just (UTCTime (fromGregorian 2030 1 1) 0)
+        }
+
+oIDCAuthApp :: Sessions -> (Html () -> Html ()) -> ProcessIO AuthApplication
+oIDCAuthApp sessions mkIndexHtml = do
+    JwkStorage myKey <- fst <$> newProcessMemory "display-key.jwk" (JwkStorage <$> liftIO generateKey)
+    let jwtSettings = defaultJWTSettings myKey
+    let cfg = cookieSettings :. jwtSettings :. EmptyContext
+    env <- ask
+    let authSrv = authServer env.os env.process sessions mkIndexHtml jwtSettings
+    let app = Servant.serveWithContextT (Proxy @AuthAPI) cfg id authSrv
+    pure $ AuthApplication app

--- a/src/Butler/Auth/OIDC.hs
+++ b/src/Butler/Auth/OIDC.hs
@@ -189,13 +189,15 @@ oIDCAuthApp sessions mkIndexHtml = do
     let jwtSettings = defaultJWTSettings myKey
     let cfg = cookieSettings :. jwtSettings :. EmptyContext
     env <- ask
+    Just client_id <- liftIO $ getEnv "OIDC_ID"
+    Just client_password <- liftIO $ getEnv "OIDC_PASSWORD"
     oidcenv <-
         liftIO . initOIDCEnv $
             OIDCProviderConfig
                 "https://accounts.google.com"
-                "my_client_id"
-                "my_client_secret"
-                "https://localhost:8080"
+                (decodeUtf8 client_id)
+                (decodeUtf8 client_password)
+                "https://localhost:8080/"
                 (Just "email")
                 False
                 "Test"

--- a/src/Butler/Auth/OIDC.hs
+++ b/src/Butler/Auth/OIDC.hs
@@ -15,6 +15,7 @@ import Data.ByteString.Base64 qualified as B64
 import Data.ByteString.Char8 qualified as B
 import Data.ByteString.Lazy qualified as BSL
 import Data.Map.Strict qualified as HM
+import Data.Text (dropWhileEnd)
 import Data.Time (UTCTime (..), fromGregorian)
 import Network.HTTP.Client (Manager)
 import Network.HTTP.Client.TLS (newTlsManager)
@@ -81,8 +82,7 @@ initOIDCEnv providerConfig@OIDCProviderConfig{..} = do
     manager <- newTlsManager
     provider <- O.discover opIssuerURL manager
     sessionStoreStorage <- newMVar HM.empty
-    -- TODO ensure '/' before '_cb'
-    let redirectUri = encodeUtf8 opAppPublicURL <> "_cb"
+    let redirectUri = encodeUtf8 (dropWhileEnd (== '/') opAppPublicURL) <> "/_cb"
         oidc = O.setCredentials clientId clientSecret redirectUri (O.newOIDC provider)
     pure OIDCEnv{..}
   where

--- a/src/Butler/Display/Session.hs
+++ b/src/Butler/Display/Session.hs
@@ -64,6 +64,7 @@ newtype SessionProvider = SessionProvider Text
     deriving newtype (Eq)
 
 instance From SessionProvider Text where from = coerce
+instance ToJSON SessionProvider where toJSON = String . coerce
 
 -- | The default provider
 localProvider :: SessionProvider

--- a/src/ButlerDemos.hs
+++ b/src/ButlerDemos.hs
@@ -47,8 +47,9 @@ import Butler.Service.FileService
 import Butler.Service.SoundBlaster
 import Butler.Service.SshAgent
 
-import Butler.App.SocialLogin (socialLoginApp)
-import Butler.Auth (publicOIDCDisplayApp)
+import Butler.App.SocialLogin
+import Butler.Auth
+import Butler.Auth.OIDC
 import Lucid.XStatic
 import XStatic.Butler as XStatic
 import XStatic.Hyperscript qualified as XStatic
@@ -101,7 +102,13 @@ multiDesktop = run (demoDesktop [])
 
 -- | Demonstrate a social login app
 demoSocialAuth :: IO ()
-demoSocialAuth = run $ serveApps (publicOIDCDisplayApp "Demo social login app" Nothing) [socialLoginApp]
+demoSocialAuth = do
+    Just client_id <- liftIO $ getEnv "OIDC_ID"
+    Just client_password <- liftIO $ getEnv "OIDC_SECRET"
+    run $
+        serveApps
+            (publicOIDCDisplayApp (OIDCClientID client_id) (OIDCClientSecret client_password) "Demo social login app" Nothing)
+            [socialLoginApp]
 
 demoDesktop :: [App] -> ProcessIO Void
 demoDesktop extraApps = withButlerSupervisor \butlerSupervisor -> do

--- a/src/ButlerDemos.hs
+++ b/src/ButlerDemos.hs
@@ -47,6 +47,7 @@ import Butler.Service.FileService
 import Butler.Service.SoundBlaster
 import Butler.Service.SshAgent
 
+import Butler.Auth (publicOIDCDisplayApp)
 import Lucid.XStatic
 import XStatic.Butler as XStatic
 import XStatic.Hyperscript qualified as XStatic
@@ -56,7 +57,6 @@ import XStatic.Remixicon qualified as XStatic
 import XStatic.SweetAlert2 qualified as XStatic
 import XStatic.Winbox qualified as XStatic
 import XStatic.Xterm qualified as XStatic
-import Butler.Auth (publicOIDCDisplayApp)
 
 -- | Demonstrate running external processes.
 vncServer :: ProcessIO ()

--- a/src/ButlerDemos.hs
+++ b/src/ButlerDemos.hs
@@ -56,6 +56,7 @@ import XStatic.Remixicon qualified as XStatic
 import XStatic.SweetAlert2 qualified as XStatic
 import XStatic.Winbox qualified as XStatic
 import XStatic.Xterm qualified as XStatic
+import Butler.Auth (publicOIDCDisplayApp)
 
 -- | Demonstrate running external processes.
 vncServer :: ProcessIO ()
@@ -96,6 +97,10 @@ demoDashboard = serveDashboardApps (publicDisplayApp "Demo dashboard" Nothing) [
 -- | Demonstrate a more complicated apps deployment with a lobby to dispatch client based on the path.
 multiDesktop :: IO ()
 multiDesktop = run (demoDesktop [])
+
+-- | Demonstrate a social login app
+demoSocialAuth :: IO ()
+demoSocialAuth = run $ serveApps (publicOIDCDisplayApp "Demo social login app" Nothing) [clockApp]
 
 demoDesktop :: [App] -> ProcessIO Void
 demoDesktop extraApps = withButlerSupervisor \butlerSupervisor -> do

--- a/src/ButlerDemos.hs
+++ b/src/ButlerDemos.hs
@@ -47,6 +47,7 @@ import Butler.Service.FileService
 import Butler.Service.SoundBlaster
 import Butler.Service.SshAgent
 
+import Butler.App.SocialLogin (socialLoginApp)
 import Butler.Auth (publicOIDCDisplayApp)
 import Lucid.XStatic
 import XStatic.Butler as XStatic
@@ -100,7 +101,7 @@ multiDesktop = run (demoDesktop [])
 
 -- | Demonstrate a social login app
 demoSocialAuth :: IO ()
-demoSocialAuth = run $ serveApps (publicOIDCDisplayApp "Demo social login app" Nothing) [clockApp]
+demoSocialAuth = run $ serveApps (publicOIDCDisplayApp "Demo social login app" Nothing) [socialLoginApp]
 
 demoDesktop :: [App] -> ProcessIO Void
 demoDesktop extraApps = withButlerSupervisor \butlerSupervisor -> do


### PR DESCRIPTION
Only support Google Auth. The demo App propose a login button that redirect to Google in order to authenticate. Once authenticated the user is redirected to the demo App and the username is displayed.