### PR TITLE
WebSocket: update implementation to use cookie authentication

### DIFF
--- a/butler.cabal
+++ b/butler.cabal
@@ -183,7 +183,6 @@ library
     , servant-auth-server
     , servant-lucid
     , servant-server
-    , servant-websockets
     , sqlite-simple
     , stm
     , tasty
@@ -198,6 +197,7 @@ library
     , unordered-containers
     , uuid
     , wai
+    , wai-websockets
     , warp
     , warp-tls
     , websockets
@@ -305,7 +305,6 @@ executable butler
     , servant-auth-server
     , servant-lucid
     , servant-server
-    , servant-websockets
     , sqlite-simple
     , stm
     , tasty
@@ -320,6 +319,7 @@ executable butler
     , unordered-containers
     , uuid
     , wai
+    , wai-websockets
     , warp
     , warp-tls
     , websockets
@@ -437,7 +437,6 @@ test-suite spec
     , servant-auth-server
     , servant-lucid
     , servant-server
-    , servant-websockets
     , sqlite-simple
     , stm
     , tasty
@@ -452,6 +451,7 @@ test-suite spec
     , unordered-containers
     , uuid
     , wai
+    , wai-websockets
     , warp
     , warp-tls
     , websockets

--- a/package.yaml
+++ b/package.yaml
@@ -103,11 +103,11 @@ dependencies:
   - warp-tls
 
   # Servant types
-  - servant-websockets
   - servant
   - servant-server
   - servant-auth
   - servant-auth-server
+  - wai-websockets
 
   # Extra
   - PyF

--- a/src/Butler/Auth/Guest.hs
+++ b/src/Butler/Auth/Guest.hs
@@ -44,7 +44,7 @@ loginServer os process sessions mkIndexHtml jwtSettings auth mWorkspace = indexR
             mSession <- atomically (lookupSession sessions sessionID)
             case mSession of
                 Just _ ->
-                    pure $ mkIndexHtml (websocketHtml (workspaceUrl mWorkspace) sessionID)
+                    pure $ mkIndexHtml (websocketHtml (workspaceUrl mWorkspace))
                 Nothing -> do
                     liftIO $ runProcessIO os process $ logError "no more auth?" ["id" .= sessionID]
                     pure "Unknown session"

--- a/src/Butler/Auth/Invitation.hs
+++ b/src/Butler/Auth/Invitation.hs
@@ -66,7 +66,7 @@ rootServer sessions mkIndexHtml ar mWorkspace = indexRoute
         Authenticated sessionID -> do
             mSession <- atomically (lookupSession sessions sessionID)
             case mSession of
-                Just _ -> pure $ mkIndexHtml (websocketHtml (workspaceUrl mWorkspace) sessionID)
+                Just _ -> pure $ mkIndexHtml (websocketHtml (workspaceUrl mWorkspace))
                 Nothing -> loginPage
         _OtherAuth -> loginPage
       where

--- a/src/Butler/Display/GUI.hs
+++ b/src/Butler/Display/GUI.hs
@@ -38,7 +38,6 @@ import Data.Text qualified as Text
 import Data.Text.Read qualified as Text
 
 import Butler.Display.Client
-import Butler.Display.Session
 
 -- | Callback when the html change, e.g. on TVar update.
 renderOnChange :: MonadIO m => HtmlT STM () -> (HtmlT STM () -> m ()) -> m Void
@@ -126,15 +125,13 @@ topRightMenu items = do
             traverse_ div_ items
 
 -- | Create the htmx websocket root element
-websocketHtml :: Text -> SessionID -> Html ()
-websocketHtml pathPrefix sessionID = do
-    let wsUrl = pathPrefix <> "ws/htmx" <> queryArgs
+websocketHtml :: Text -> Html ()
+websocketHtml pathPrefix = do
+    let wsUrl = pathPrefix <> "ws/htmx"
     with div_ [id_ "display-ws", class_ "h-full", makeAttribute "hx-ext" "ws", makeAttribute "ws-connect" wsUrl] do
         with div_ [id_ "display-wins", class_ "h-full"] mempty
         -- script to get extra websocket url from javascript
-        script_ $ "globalThis.wsUrl = n => 'wss://' + window.location.host + '" <> pathPrefix <> "ws/' + n + '" <> queryArgs <> "';"
-  where
-    queryArgs = "?session=" <> from sessionID
+        script_ $ "globalThis.wsUrl = n => 'wss://' + window.location.host + '" <> pathPrefix <> "ws/' + n;"
 
 -- | Display the content in a splash screen
 splashHtml :: Monad m => HtmlT m () -> HtmlT m ()


### PR DESCRIPTION
Replace servant-websockets with wai-websockets to handle cookie based authentication. This is necessary until https://github.com/moesenle/servant-websockets/issues/12