### PR TITLE
Demo Social Login - Add a session state to show logged user recover session

### DIFF
--- a/source/libraries/desktop/Butler/App/SocialLogin.hs
+++ b/source/libraries/desktop/Butler/App/SocialLogin.hs
@@ -1,12 +1,18 @@
 module Butler.App.SocialLogin (socialLoginApp) where
 
 import Butler
+import Butler.App (withEvent)
+import Butler.Core.Dynamic (getSharedDynamic)
 import Butler.Display.Session
 
-appHtml :: Monad m => AppID -> UserName -> Maybe SessionProvider -> HtmlT m ()
-appHtml wid username mProvider =
-    with div_ [wid_ wid "w", class_ "flex m-auto"] do
-        with div_ [class_ "m-auto flex flex-col items-center justify-center gap-1"] do
+newtype APPState = APPState Text deriving (Generic)
+
+instance Serialise APPState
+
+appHtml :: Monad m => AppID -> UserName -> Maybe SessionProvider -> Text -> HtmlT m ()
+appHtml wid username mProvider secretText =
+    div_ [wid_ wid "w", class_ "flex m-auto"] do
+        div_ [class_ "m-auto flex flex-col items-center justify-center gap-1"] do
             case mProvider of
                 Just provider -> do
                     logoutButton
@@ -14,6 +20,15 @@ appHtml wid username mProvider =
                 Nothing -> do
                     loginButton
                     div_ [] $ toHtml $ "Your are in a guest session and your username is: " <> show username
+            div_ [] $ do
+                div_ [class_ "flex flex-row gap-2"] do
+                    withEvent wid "setSecret" [] $ do
+                        form_ $ do
+                            label_ "Your secret text: "
+                            input_ [type_ "text", name_ "secret-text", value_ secretText, size_ "30"]
+                            saveButton
+                div_ [id_ "saved-script"] ""
+                div_ [id_ "saved"] ""
   where
     loginButton =
         div_
@@ -31,6 +46,24 @@ appHtml wid username mProvider =
             , hxTrigger_ "click"
             ]
             "Logout"
+    saveButton =
+        button_
+            [ wid_ wid "save-button"
+            , wsSend
+            , type_ "submit"
+            , class_ "cursor-pointer pl-1 border-2"
+            , hxTrigger_ "click"
+            ]
+            "Save"
+
+hideAfter :: Text
+hideAfter =
+    [raw|
+setTimeout(() => {
+  const elm = document.getElementById('saved');
+  elm.style.display = 'none';
+}, 1500);
+|]
 
 socialLoginApp :: App
 socialLoginApp =
@@ -42,6 +75,11 @@ socialLoginApp =
 
 startSocialLoginApp :: AppContext -> ProcessIO ()
 startSocialLoginApp ctx = do
+    let appState = APPState "My secret text"
+        memAddr = "app-state-" <> showT ctx.wid <> ".bin"
+    -- Use getSharedDynamic to use a single list of secret for the workspace
+    (_, state) <- getSharedDynamic ctx.shared.dynamics "social-secret" do
+        newProcessMemory (from memAddr) (pure appState)
     forever do
         res <- atomically $ readPipe ctx.pipe
         case res of
@@ -49,7 +87,8 @@ startSocialLoginApp ctx = do
                 atomically $ do
                     username <- readTVar client.session.username
                     mProvider <- readTVar client.session.provider
-                    sendHtml client $ appHtml ctx.wid username mProvider
+                    APPState secretText <- readMemoryVar state
+                    sendHtml client $ appHtml ctx.wid username mProvider secretText
             AppTrigger ev -> case ev.trigger of
                 TriggerName "login-button" -> do
                     sendsHtml ctx.shared.clients $
@@ -59,5 +98,13 @@ startSocialLoginApp ctx = do
                     sendsHtml ctx.shared.clients $
                         with div_ [wid_ ctx.wid "w"] do
                             script_ "window.location.href = \"/_logout\""
+                TriggerName "save-button" -> do
+                    case ev.body ^? key "secret-text" . _String of
+                        Just secretText -> do
+                            atomically $ modifyMemoryVar state $ const $ APPState secretText
+                            sendsHtml ctx.shared.clients $ do
+                                div_ [id_ "saved", class_ "bg-green-200"] "saved !"
+                                div_ [id_ "saved-script"] $ script_ hideAfter
+                        Nothing -> pure ()
                 _ -> logError "Unknown event" ["ev" .= ev]
             _ -> pure ()


### PR DESCRIPTION
This change:

- adds a state in the social login demo application in order to demonstrate that an authenticated user with the IDP can recover its own state between connections.