### PR TITLE
Auth.OIDC - Add a '_delete' endpoint to remove a session

### DIFF
--- a/source/libraries/desktop/Butler/App/SocialLogin.hs
+++ b/source/libraries/desktop/Butler/App/SocialLogin.hs
@@ -20,32 +20,29 @@ appHtml wid username mProvider secretText =
                 Nothing -> do
                     loginButton
                     div_ [] $ toHtml $ "Your are in a guest session and your username is: " <> show username
-            div_ [] $ do
-                div_ [class_ "flex flex-row gap-2"] do
-                    withEvent wid "setSecret" [] $ do
-                        form_ $ do
-                            label_ "Your secret text: "
-                            input_ [type_ "text", name_ "secret-text", value_ secretText, size_ "30"]
-                            saveButton
-                div_ [id_ "saved-script"] ""
-                div_ [id_ "saved"] ""
+            deleteAccountButton
+            div_ [] "Your secret text is stored in your session. You can update it and see that it is persited by session."
+            div_ [class_ "flex flex-row gap-2"] do
+                withEvent wid "setSecret" [] $ do
+                    form_ $ do
+                        label_ "Your secret text: "
+                        input_ [type_ "text", name_ "secret-text", value_ secretText, size_ "30"]
+                        saveButton
+            div_ [id_ "saved-script"] ""
+            div_ [id_ "saved"] ""
   where
-    loginButton =
+    button :: Monad m => Text -> Text -> HtmlT m ()
+    button bId label =
         div_
-            [ wid_ wid "login-button"
+            [ wid_ wid bId
             , wsSend
             , class_ "bg-slate-200 cursor-pointer pl-1"
             , hxTrigger_ "click"
             ]
-            "Login with Google"
-    logoutButton =
-        div_
-            [ wid_ wid "logout-button"
-            , wsSend
-            , class_ "bg-slate-200 cursor-pointer pl-1"
-            , hxTrigger_ "click"
-            ]
-            "Logout"
+            $ toHtml label
+    loginButton = button "login-button" "Login with Google"
+    logoutButton = button "logout-button" "Logout"
+    deleteAccountButton = button "delete-account-button" "Delete my session/account"
     saveButton =
         button_
             [ wid_ wid "save-button"
@@ -75,7 +72,7 @@ socialLoginApp =
 
 startSocialLoginApp :: AppContext -> ProcessIO ()
 startSocialLoginApp ctx = do
-    let appState = APPState "My secret text"
+    let appState = APPState "My default secret text as guest"
         memAddr = "app-state-" <> showT ctx.wid <> ".bin"
     -- Use getSharedDynamic to use a single list of secret for the workspace
     (_, state) <- getSharedDynamic ctx.shared.dynamics "social-secret" do
@@ -90,14 +87,9 @@ startSocialLoginApp ctx = do
                     APPState secretText <- readMemoryVar state
                     sendHtml client $ appHtml ctx.wid username mProvider secretText
             AppTrigger ev -> case ev.trigger of
-                TriggerName "login-button" -> do
-                    sendsHtml ctx.shared.clients $
-                        with div_ [wid_ ctx.wid "w"] do
-                            script_ "window.location.href = \"/_login\""
-                TriggerName "logout-button" -> do
-                    sendsHtml ctx.shared.clients $
-                        with div_ [wid_ ctx.wid "w"] do
-                            script_ "window.location.href = \"/_logout\""
+                TriggerName "login-button" -> redirectTo "/_login"
+                TriggerName "logout-button" -> redirectTo "/_logout"
+                TriggerName "delete-account-button" -> redirectTo "/_delete"
                 TriggerName "save-button" -> do
                     case ev.body ^? key "secret-text" . _String of
                         Just secretText -> do
@@ -108,3 +100,9 @@ startSocialLoginApp ctx = do
                         Nothing -> pure ()
                 _ -> logError "Unknown event" ["ev" .= ev]
             _ -> pure ()
+  where
+    redirectTo :: Text -> ProcessIO ()
+    redirectTo dest =
+        sendsHtml ctx.shared.clients $
+            with div_ [wid_ ctx.wid "w"] do
+                script_ $ "window.location.href = \"" <> dest <> "\""


### PR DESCRIPTION
The purpose of this endpoint is to perform the deletion of the current session data and a then logout.

This change also makes use of this new endpoint into the SocialLogin demo app.